### PR TITLE
Fix device duplication in casting menu

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/ui/SettingsFragment.java
+++ b/play-services-core/src/main/java/org/microg/gms/ui/SettingsFragment.java
@@ -1,10 +1,15 @@
 package org.microg.gms.ui;
 
+import android.content.ComponentName;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
 import androidx.navigation.fragment.NavHostFragment;
+import androidx.preference.Preference;
+import androidx.preference.SwitchPreferenceCompat;
 
+import com.google.android.gms.cast.media.CastMediaRouteProviderService;
 import com.mgoogle.android.gms.R;
 
 import org.microg.gms.checkin.CheckinPrefs;
@@ -12,42 +17,68 @@ import org.microg.gms.gcm.GcmDatabase;
 import org.microg.gms.gcm.GcmPrefs;
 import org.microg.tools.ui.ResourceSettingsFragment;
 
-public class SettingsFragment extends ResourceSettingsFragment {
+public class SettingsFragment extends ResourceSettingsFragment
+{
 
     public static final String PREF_ABOUT = "pref_about";
     public static final String PREF_GCM = "pref_gcm";
     public static final String PREF_SNET = "pref_snet";
     public static final String PREF_UNIFIEDNLP = "pref_unifiednlp";
     public static final String PREF_CHECKIN = "pref_checkin";
+    public static final String PREF_CAST_ENABLED = "pref_cast_enabled";
 
-    public SettingsFragment() {
+    public SettingsFragment()
+    {
         preferencesResource = R.xml.preferences_start;
     }
 
     @Override
-    public void onCreatePreferences(@Nullable Bundle savedInstanceState, String rootKey) {
+    public void onCreatePreferences(@Nullable Bundle savedInstanceState, String rootKey)
+    {
         super.onCreatePreferences(savedInstanceState, rootKey);
         updateDetails();
     }
 
     @Override
-    public void onResume() {
+    public void onResume()
+    {
         super.onResume();
         updateDetails();
     }
 
-    private void updateDetails() {
+    private void updateDetails()
+    {
         findPreference(PREF_ABOUT).setSummary(getString(R.string.about_version_str, AboutFragment.getSelfVersion(getContext())));
         findPreference(PREF_ABOUT).setOnPreferenceClickListener(preference -> {
             NavHostFragment.findNavController(SettingsFragment.this).navigate(R.id.openAbout);
             return true;
         });
-        if (GcmPrefs.get(getContext()).isEnabled()) {
+        findPreference(PREF_CAST_ENABLED).setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
+        {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue)
+            {
+                if ((boolean) newValue)
+                    getContext().getPackageManager().setComponentEnabledSetting(
+                            new ComponentName(getContext().getApplicationContext(), CastMediaRouteProviderService.class),
+                            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                            PackageManager.DONT_KILL_APP);
+                else
+                    getContext().getPackageManager().setComponentEnabledSetting(
+                            new ComponentName(getContext().getApplicationContext(), CastMediaRouteProviderService.class),
+                            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                            PackageManager.DONT_KILL_APP);
+                return true;
+            }
+        });
+        if (GcmPrefs.get(getContext()).isEnabled())
+        {
             GcmDatabase database = new GcmDatabase(getContext());
             int regCount = database.getRegistrationList().size();
             database.close();
             findPreference(PREF_GCM).setSummary(getString(R.string.service_status_enabled_short) + " - " + getResources().getQuantityString(R.plurals.gcm_registered_apps_counter, regCount, regCount));
-        } else {
+        } else
+        {
             findPreference(PREF_GCM).setSummary(R.string.service_status_disabled_short);
         }
         findPreference(PREF_GCM).setOnPreferenceClickListener(preference -> {

--- a/play-services-core/src/main/java/org/microg/gms/ui/SettingsFragment.java
+++ b/play-services-core/src/main/java/org/microg/gms/ui/SettingsFragment.java
@@ -25,7 +25,7 @@ public class SettingsFragment extends ResourceSettingsFragment
     public static final String PREF_SNET = "pref_snet";
     public static final String PREF_UNIFIEDNLP = "pref_unifiednlp";
     public static final String PREF_CHECKIN = "pref_checkin";
-    public static final String PREF_CAST_ENABLED = "pref_cast_enabled";
+    public static final String PREF_CAST_DOUBLE_FIX_ENABLED = "pref_cast_double_fix_enabled";
 
     public SettingsFragment()
     {
@@ -53,11 +53,11 @@ public class SettingsFragment extends ResourceSettingsFragment
             NavHostFragment.findNavController(SettingsFragment.this).navigate(R.id.openAbout);
             return true;
         });
-        findPreference(PREF_CAST_ENABLED).setOnPreferenceChangeListener((preference, newValue) -> {
+        findPreference(PREF_CAST_DOUBLE_FIX_ENABLED).setOnPreferenceChangeListener((preference, newValue) -> {
             boolean isEnabled = (boolean) newValue;
             getContext().getPackageManager().setComponentEnabledSetting(
                     new ComponentName(getContext().getApplicationContext(), CastMediaRouteProviderService.class),
-                    isEnabled ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED : PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                    isEnabled ? PackageManager.COMPONENT_ENABLED_STATE_DISABLED : PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
                     PackageManager.DONT_KILL_APP);
             return true;
         });

--- a/play-services-core/src/main/java/org/microg/gms/ui/SettingsFragment.java
+++ b/play-services-core/src/main/java/org/microg/gms/ui/SettingsFragment.java
@@ -53,23 +53,13 @@ public class SettingsFragment extends ResourceSettingsFragment
             NavHostFragment.findNavController(SettingsFragment.this).navigate(R.id.openAbout);
             return true;
         });
-        findPreference(PREF_CAST_ENABLED).setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
-        {
-            @Override
-            public boolean onPreferenceChange(Preference preference, Object newValue)
-            {
-                if ((boolean) newValue)
-                    getContext().getPackageManager().setComponentEnabledSetting(
-                            new ComponentName(getContext().getApplicationContext(), CastMediaRouteProviderService.class),
-                            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
-                            PackageManager.DONT_KILL_APP);
-                else
-                    getContext().getPackageManager().setComponentEnabledSetting(
-                            new ComponentName(getContext().getApplicationContext(), CastMediaRouteProviderService.class),
-                            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
-                            PackageManager.DONT_KILL_APP);
-                return true;
-            }
+        findPreference(PREF_CAST_ENABLED).setOnPreferenceChangeListener((preference, newValue) -> {
+            boolean isEnabled = (boolean) newValue;
+            getContext().getPackageManager().setComponentEnabledSetting(
+                    new ComponentName(getContext().getApplicationContext(), CastMediaRouteProviderService.class),
+                    isEnabled ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED : PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                    PackageManager.DONT_KILL_APP);
+            return true;
         });
         if (GcmPrefs.get(getContext()).isEnabled())
         {

--- a/play-services-core/src/main/res/drawable/ic_cast_black.xml
+++ b/play-services-core/src/main/res/drawable/ic_cast_black.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorAccent"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M21,3L3,3c-1.1,0 -2,0.9 -2,2v3h2L3,5h18v14h-7v2h7c1.1,0 2,-0.9 2,-2L23,5c0,-1.1 -0.9,-2 -2,-2zM1,18v3h3c0,-1.66 -1.34,-3 -3,-3zM1,14v2c2.76,0 5,2.24 5,5h2c0,-3.87 -3.13,-7 -7,-7zM1,10v2c4.97,0 9,4.03 9,9h2c0,-6.08 -4.93,-11 -11,-11z"
+      android:fillColor="#000000"/>
+</vector>

--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -106,6 +106,7 @@ This can take a couple of minutes."</string>
     <string name="pref_gcm_confirm_new_apps_summary">Ask before registering a new app to receive push notifications</string>
 
     <string name="pref_about_title">About Vanced microG</string>
+    <string name="pref_cast_service">Cast service</string>
 
     <string name="pref_checkin_enable_summary">Registers your device to Google services and creates a unique device identifier. Vanced microG strips identifying bits other than your Google account name from registration data.</string>
     <string name="pref_info_status">Status</string>

--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -106,7 +106,7 @@ This can take a couple of minutes."</string>
     <string name="pref_gcm_confirm_new_apps_summary">Ask before registering a new app to receive push notifications</string>
 
     <string name="pref_about_title">About Vanced microG</string>
-    <string name="pref_cast_service">Cast service</string>
+    <string name="pref_cast_double_fix">Cast duplication fix</string>
 
     <string name="pref_checkin_enable_summary">Registers your device to Google services and creates a unique device identifier. Vanced microG strips identifying bits other than your Google account name from registration data.</string>
     <string name="pref_info_status">Status</string>
@@ -136,5 +136,6 @@ This can take a couple of minutes."</string>
     <string name="pref_snet_status_official_info">official server</string>
     <string name="pref_snet_status_third_party_info">third-party server</string>
     <string name="pref_snet_status_self_signed_info">self-signed certificate</string>
+    <string name="pref_cast_double_fix_summary">Enable this if you see duplicates in your casting menu</string>
 
 </resources>

--- a/play-services-core/src/main/res/xml/preferences_start.xml
+++ b/play-services-core/src/main/res/xml/preferences_start.xml
@@ -43,10 +43,11 @@
                 android:targetPackage="com.mgoogle.android.gms" />
         </Preference>
         <SwitchPreferenceCompat
-            android:key="pref_cast_enabled"
-            android:title="@string/pref_cast_service"
+            android:key="pref_cast_double_fix_enabled"
+            android:title="@string/pref_cast_double_fix"
             android:icon="@drawable/ic_cast_black"
-            android:defaultValue="true"/>
+            android:summary="@string/pref_cast_double_fix_summary"
+            android:defaultValue="false"/>
     </PreferenceCategory>
     <PreferenceCategory android:layout="@layout/preference_category_no_label">
         <Preference

--- a/play-services-core/src/main/res/xml/preferences_start.xml
+++ b/play-services-core/src/main/res/xml/preferences_start.xml
@@ -42,6 +42,11 @@
                 android:targetClass="org.microg.gms.ui.GoogleMoreFragment$AsActivity"
                 android:targetPackage="com.mgoogle.android.gms" />
         </Preference>
+        <SwitchPreferenceCompat
+            android:key="pref_cast_enabled"
+            android:title="@string/pref_cast_service"
+            android:icon="@drawable/ic_cast_black"
+            android:defaultValue="true"/>
     </PreferenceCategory>
     <PreferenceCategory android:layout="@layout/preference_category_no_label">
         <Preference


### PR DESCRIPTION
If you have the original google services alongside Vanced microg you will get duplicate devices in the cast menu. 
This setting added to microg enables you to enable/disable the cast service for Vanced microg to get around this issue.