### PR TITLE
Made Settings icon visible in launcher

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -276,7 +276,7 @@
             android:theme="@style/Theme.AppCompat.DayNight">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.APPLICATION_PREFERENCES" />


### PR DESCRIPTION
I kinda haven't tested because my machine just freezes when trying to build mug lol. Technically icon should appear, we can safely remove mug settings icon from manager if this turns out to be working